### PR TITLE
Correct file size in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## appmetrics.js
 
-> A small (803KB gzip) library for measuring things in your web app, annotating the DevTools timeline, and reporting the results to Google Analytics.
+> A small (803 bytes gzipped) library for measuring things in your web app, annotating the DevTools timeline, and reporting the results to Google Analytics.
 
 This library is a small wrapper around the the [User Timing API](https://developer.mozilla.org/en-US/docs/Web/API/User_Timing_API). It makes it easier to use. appmetrics.js allows you to instrument your app, record performance metrics, and (optionally) report those metrics to [Google Analytics](https://analytics.google.com). Over time, you'll be able to track the performance of your web app!
 


### PR DESCRIPTION
Hi guys - just came across appmetrics and wanted to say the title and docs are incorrect regarding the size.

In the title:
```
A small (800kb) library for measuring things in your web app and reporting the results to Google Analytics.
```
should read:
```
A small (800 byte) library for measuring things in your web app and reporting the results to Google Analytics.
```