### PR TITLE
Support importing in Webpack with UglifyJS in the chain

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "engines": {
     "node": ">=6.0.0"
   },
-  "main": "./src/appmetrics.js",
+  "main": "./dist/appmetrics.min.js",
   "keywords": [
     "metrics",
     "analytics",


### PR DESCRIPTION
This tweak changes the import target of appmetrics.js to use the `dist` version. That way it works with build systems that use UglifyJS to minify code.